### PR TITLE
rework(defaults): Remove sudo-rs from default modules

### DIFF
--- a/modules/default/icedos.nix
+++ b/modules/default/icedos.nix
@@ -77,7 +77,6 @@
           "nix-health"
           "nixfmt"
           "ssh"
-          "sudo-rs"
           "toolset"
           "zsh"
         ];
@@ -89,6 +88,7 @@
         modules = [
           "kitty"
           "neovim"
+          "sudo-rs"
         ];
       }
     ];


### PR DESCRIPTION
Since sudo-rs is a fairly new project, it may not be best to force it to the user