### PR TITLE
Remove unnecessary option for celluloid

### DIFF
--- a/modules/celluloid/celluloid.conf
+++ b/modules/celluloid/celluloid.conf
@@ -2,8 +2,6 @@
 
 # Because we want high quality
 profile=gpu-hq
-# Because it can play DoVi and is faster
-vo=gpu-next
 # Hardware acceleration (faster, less energy consumption)
 hwdec=auto-safe
 # Force modern standards


### PR DESCRIPTION
`vo=gpu-next` is now the default option, so we don't need this anymore.